### PR TITLE
Fix LinkMetadataService availability for tvOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     
   build-swiftpm:
     name: Build SwiftPM
-    uses: oversizedev/GithubWorkflows/.github/workflows/build-swiftpm.yml@main
+    uses: oversizedev/GithubWorkflows/.github/workflows/build-swiftpm-all-platforms.yml@main
     strategy:
       matrix:
         packages:
@@ -25,15 +25,8 @@ jobs:
           - OversizeContactsService
           - OversizeNotificationService
           - OversizeFileManagerService
-        destination:
-          - platform=iOS Simulator,name=iPhone 17,OS=26.2
-          - platform=watchOS Simulator,name=Apple Watch SE 3 (40mm),OS=26.2
-          - platform=tvOS Simulator,name=Apple TV 4K (3rd generation) (at 1080p),OS=26.2
-          - platform=macOS,arch=arm64
-          
     with:
       package: ${{ matrix.packages }}
-      destination: ${{ matrix.destination }}
     secrets: inherit
     
 #  tests:

--- a/Sources/OversizeWebService/LinkMetadataService.swift
+++ b/Sources/OversizeWebService/LinkMetadataService.swift
@@ -13,7 +13,7 @@ import UIKit
 import AppKit
 #endif
 
-@available(macOS 13.0, iOS 16.0, tvOS 16.0, *)
+@available(macOS 13.0, iOS 16.0, tvOS 18.0, *)
 public actor LinkMetadataService {
     public init() {}
 

--- a/Sources/OversizeWebService/ServiceRegistering.swift
+++ b/Sources/OversizeWebService/ServiceRegistering.swift
@@ -7,7 +7,7 @@
 import FactoryKit
 import Foundation
 
-@available(macOS 13.0, iOS 16.0, tvOS 16.0, *)
+@available(macOS 13.0, iOS 16.0, tvOS 18.0, *)
 public extension Container {
     var linkMetadataService: Factory<LinkMetadataService> {
         self { LinkMetadataService() }


### PR DESCRIPTION
## Summary
`LPMetadataProvider` from LinkPresentation is only available on tvOS 18, but `LinkMetadataService` (and its `Container` registration) were annotated `tvOS 16.0`. This breaks tvOS builds of any package depending on `OversizeWebService` (e.g. OversizeKit NoticeKit/NotificationKit schemes).

## Changes
- Raise `LinkMetadataService` availability to `tvOS 18.0`.
- Match the `Container.linkMetadataService` registration to `tvOS 18.0`.

## Verification
Fixes tvOS compile errors: `'LPMetadataProvider' is only available in tvOS 18.0 or newer` in `Sources/OversizeWebService/LinkMetadataService.swift`.